### PR TITLE
Change widgetbot shard and disable send

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -25,7 +25,7 @@
     </head>
     <body>
         <widgetbot
-            shard="https://cl1.widgetbot.io"
+            shard="https://cl2.widgetbot.io"
             server="461495552039714817"
             channel="461495552039714819"
             width="100%"


### PR DESCRIPTION
To avoid further issues, the previous bot has been removed from the server and a new shard was invited with limited permissions. This also prevents any possibility, albeit unlikely, that the old instance can somehow reconnect to the server.