### PR TITLE
Added Emulicious's Discord server

### DIFF
--- a/discord_related.md
+++ b/discord_related.md
@@ -34,6 +34,7 @@ layout: default
 - [Provenance (iOS/tvOS)](https://discord.gg/4TK7PU5)
 - [Mu (Palm OS)](https://discord.gg/hWSz8VN)
 - [SquirrelJME (Java ME 8)](https://discord.gg/9PkMMKt)
+- [Emulicious (Master System, Game Boy, MSX)](https://discord.gg/YuKjBUF)
 
 ## Emulation Community Servers
 - [RetroArch/libretro](https://discord.gg/rbJJaR9)


### PR DESCRIPTION
Added Emulicious's Discord server to the list of Emulator Servers in discord_related.md.
Emulicious emulates the SEGA Master System + Game Gear, the Game Boy and the MSX.
In the Master System community it is considered the most accurate Master System emulator and its Game Boy emulation is fairly accurate as well (See https://daid.github.io/GBEmulatorShootout/).